### PR TITLE
fix: advanced章のloop_basic.ymlテストを修正

### DIFF
--- a/chapters_test.go
+++ b/chapters_test.go
@@ -43,8 +43,10 @@ func TestRunners(t *testing.T) {
 }
 
 func TestAdvanced(t *testing.T) {
-	t.Skip("Skip advanced for now")
-	testutil.RunChapterTests(t, "examples/advanced")
+	testutil.RunTestForFiles(t, []string{
+		"examples/advanced/loop_basic.yml",
+		// 他のテストは順次修正して追加
+	})
 }
 
 func TestTestHelpers(t *testing.T) {

--- a/examples/advanced/loop_basic.yml
+++ b/examples/advanced/loop_basic.yml
@@ -1,6 +1,6 @@
 desc: 基本的なループ処理
 runners:
-  api: https://api.example.com
+  httpbin: http://localhost:8080
 
 vars:
   test_users:
@@ -13,24 +13,27 @@ vars:
 
 steps:
   # 単純な回数指定ループ
-  simple_loop:
+  - desc: 単純な回数指定ループ
     loop: 5
-    req:
-      api:///api/ping:
+    httpbin:
+      /status/200:
         get:
+          body:
     test: current.res.status == 200
-    dump:
-      iteration: i  # ループインデックス（0から開始）
+    dump: i  # ループインデックス（0から開始）
 
   # 配列の各要素に対するループ
-  array_loop:
+  - desc: 配列の各要素に対するループ
     loop:
       count: len(vars.test_users)
-    req:
-      api:///users:
+    httpbin:
+      /post:
         post:
           body:
             application/json:
               name: "{{ vars.test_users[i].name }}"
               email: "{{ vars.test_users[i].email }}"
-    test: current.res.status == 201
+    test: |
+      current.res.status == 200 &&
+      current.res.body.json.name == vars.test_users[i].name &&
+      current.res.body.json.email == vars.test_users[i].email


### PR DESCRIPTION
## 概要
advanced章のテストをスキップせずに動作させるための第一歩として、`loop_basic.yml`を修正しました。

## 変更内容
### TestAdvanced関数の修正
- `t.Skip("Skip advanced for now")`を削除してテストを有効化

### loop_basic.ymlの修正
1. **runnerの変更**
   - `api: https://api.example.com` → `httpbin: http://localhost:8080`
   - テスト環境で利用可能なhttpbinサーバーを使用

2. **steps構文の修正**
   - map形式からlist形式に変更
   - `req:`ブロックを削除し、直接`httpbin:`を使用

3. **dump構文の修正**
   - `dump: current.i` → `dump: i`
   - ループインデックスの正しい参照方法に変更

4. **HTTPリクエストの修正**
   - `get:` の後に `body:` を追加（runnの構文要件）

## テスト結果
```
=== RUN   TestAdvanced/loop_basic.yml
--- PASS: TestAdvanced (0.03s)
    --- PASS: TestAdvanced/loop_basic.yml (0.03s)
```

## 今後の作業
他の失敗しているadvanced章のテストも順次修正していく予定です。

🤖 Generated with [Claude Code](https://claude.ai/code)