### PR TITLE
fix: advanced章のテストを修正してCIを通るように調整

### DIFF
--- a/chapters_test.go
+++ b/chapters_test.go
@@ -45,7 +45,22 @@ func TestRunners(t *testing.T) {
 func TestAdvanced(t *testing.T) {
 	testutil.RunTestForFiles(t, []string{
 		"examples/advanced/loop_basic.yml",
-		// 他のテストは順次修正して追加
+		"examples/advanced/conditional_basic.yml",
+		"examples/advanced/conditional_complex.yml",
+		"examples/advanced/conditional_error_handling.yml",
+		"examples/advanced/data_generation.yml",
+		"examples/advanced/debug_output.yml",
+		// 以下のファイルは修正が困難またはエラーが発生
+		// - error_handling.yml (ランダムステータスでuntil条件が不安定)
+		// - loop_retry.yml (ランダムステータスのテストが不安定)
+		// - loop_dynamic.yml (配列インデックスアクセスのエラー)
+		// - concurrency_*.yml
+		// - custom_runner_*.yml
+		// - dependency_*.yml
+		// - include_*.yml
+		// - data_transformation.yml
+		// - common/auth.yml
+		// - level2.yml
 	})
 }
 

--- a/examples/advanced/conditional_basic.yml
+++ b/examples/advanced/conditional_basic.yml
@@ -1,43 +1,50 @@
 desc: 基本的な条件分岐
 runners:
-  api: https://api.example.com
+  httpbin: http://localhost:8080
 
 vars:
-  enable_new_feature: true
+  enable_test: true
+  test_value: 42
 
 steps:
-  # 環境による条件分岐
-  environment_specific:
-    if: env.ENVIRONMENT == "production"
-    req:
-      api:///production-only-endpoint:
-        get:
-    test: current.res.status == 200
-
   # 変数による条件分岐
-  feature_flag_check:
-    if: vars.enable_new_feature
-    req:
-      api:///new-feature:
+  - desc: 機能フラグのチェック
+    if: vars.enable_test
+    httpbin:
+      /status/200:
         get:
+          body:
     test: current.res.status == 200
 
-  # ユーザー作成ステップ（常に実行）
-  user_creation:
-    req:
-      api:///users:
+  # 条件が偽の場合（スキップされる）
+  - desc: スキップされるステップ
+    if: vars.enable_test == false
+    httpbin:
+      /status/500:
+        get:
+          body:
+    test: current.res.status == 500
+
+  # 常に実行されるステップ
+  - desc: データの投稿
+    httpbin:
+      /post:
         post:
           body:
             application/json:
-              name: "Test User"
-              email: "test@example.com"
+              value: "{{ vars.test_value }}"
+              enabled: "{{ vars.enable_test }}"
     test: |
-      current.res.status == 201 || current.res.status == 409
+      current.res.status == 200 &&
+      current.res.body.json.value == vars.test_value
 
   # 前のステップの結果による条件分岐
-  conditional_on_previous:
-    if: steps.user_creation.res.status == 201
-    req:
-      api:///users/{{ steps.user_creation.res.body.id }}/activate:
-        post:
+  - desc: 前のステップが成功した場合のみ実行
+    if: steps[2].res.status == 200
+    httpbin:
+      /anything:
+        get:
+          query:
+            previous_value: "{{ steps[2].res.body.json.value }}"
+          body:
     test: current.res.status == 200

--- a/examples/advanced/conditional_complex.yml
+++ b/examples/advanced/conditional_complex.yml
@@ -1,6 +1,6 @@
 desc: 複雑な条件式
 runners:
-  api: https://api.example.com
+  httpbin: http://localhost:8080
 
 vars:
   user_role: "admin"
@@ -9,38 +9,53 @@ vars:
     - write
     - delete
   api_version: 2
-  maintenance_end: "2024-01-01T00:00:00Z"
   test_data:
     - id: 1
       name: "Test Data 1"
-  resource_data:
-    name: "Protected Resource"
-    type: "document"
+    - id: 2
+      name: "Test Data 2"
 
 steps:
-  complex_conditions:
+  # 複数条件の組み合わせ
+  - desc: ロールと権限のチェック
     if: |
-      (env.ENVIRONMENT == "test" || env.ENVIRONMENT == "staging") &&
       vars.user_role == "admin" &&
       len(vars.test_data) > 0
-    req:
-      api:///admin/test-data:
-        post:
-          body:
-            application/json: "{{ vars.test_data }}"
-    test: current.res.status == 201
-
-  # 複数条件の組み合わせ
-  multi_condition_check:
-    if: |
-      vars.api_version >= 2 &&
-      (vars.user_permissions contains "write" || vars.user_role == "admin") &&
-      time.now() > time.parse(vars.maintenance_end, time.RFC3339)
-    req:
-      api:///v2/protected-resource:
+    httpbin:
+      /post:
         post:
           body:
             application/json:
-              action: "create"
-              data: "{{ vars.resource_data }}"
-    test: current.res.status in [200, 201]
+              role: "{{ vars.user_role }}"
+              data_count: "{{ len(vars.test_data) }}"
+    test: current.res.status == 200
+
+  # 配列の条件チェック
+  - desc: 権限チェック
+    if: |
+      vars.api_version >= 2 &&
+      ("write" in vars.user_permissions || vars.user_role == "admin")
+    httpbin:
+      /anything:
+        post:
+          body:
+            application/json:
+              action: "write"
+              permissions: "{{ vars.user_permissions }}"
+    test: |
+      current.res.status == 200 &&
+      current.res.body.json.action == "write"
+
+  # 複雑な論理式
+  - desc: 複合条件のテスト
+    if: |
+      (len(vars.test_data) >= 2 || vars.user_role == "admin") &&
+      vars.api_version > 1 &&
+      "delete" in vars.user_permissions
+    httpbin:
+      /delete:
+        delete:
+          body:
+            application/json:
+              authorized: true
+    test: current.res.status == 200

--- a/examples/advanced/conditional_error_handling.yml
+++ b/examples/advanced/conditional_error_handling.yml
@@ -1,36 +1,36 @@
 desc: エラーハンドリングと条件分岐
 runners:
-  api: https://api.example.com
+  httpbin: http://localhost:8080
 
 steps:
-  # エラー時の代替処理
-  primary_request:
-    req:
-      api:///primary-endpoint:
+  # エラー時の代替処理（404を意図的に発生させる）
+  - desc: プライマリリクエスト（失敗する）
+    httpbin:
+      /status/404:
         get:
+          body:
     test: true  # エラーでも続行
 
-  fallback_request:
-    if: steps.primary_request.res.status != 200
-    req:
-      api:///fallback-endpoint:
+  - desc: フォールバックリクエスト
+    if: steps[0].res.status != 200
+    httpbin:
+      /status/200:
         get:
+          body:
     test: current.res.status == 200
 
   # 成功時の追加処理
-  success_processing:
+  - desc: 結果の処理
     if: |
-      steps.primary_request.res.status == 200 ||
-      steps.fallback_request.res.status == 200
-    req:
-      api:///process-result:
+      steps[0].res.status == 200 ||
+      (steps[1].res != null && steps[1].res.status == 200)
+    httpbin:
+      /post:
         post:
           body:
             application/json:
               source: |
-                steps.primary_request.res.status == 200 ? "primary" : "fallback"
-              data: |
-                steps.primary_request.res.status == 200 ? 
-                steps.primary_request.res.body : 
-                steps.fallback_request.res.body
+                steps[0].res.status == 200 ? "primary" : "fallback"
+              primary_status: "{{ steps[0].res.status }}"
+              success: true
     test: current.res.status == 200

--- a/examples/advanced/data_generation.yml
+++ b/examples/advanced/data_generation.yml
@@ -1,42 +1,46 @@
 desc: 動的なテストデータ生成
 runners:
-  api: https://api.example.com
+  httpbin: http://localhost:8080
 
 vars:
-  # 動的なテストデータ生成
-  test_users: |
-    map(range(1, 11), {
-      "id": .,
-      "name": faker.name(),
-      "email": faker.email(),
-      "age": faker.randomInt(18, 65),
-      "department": faker.randomChoice(["IT", "Sales", "Marketing", "HR"]),
-      "salary": faker.randomInt(30000, 100000),
-      "active": faker.randomBool()
-    })
+  num_users: 3
+  departments:
+    - "IT"
+    - "Sales"
+    - "Marketing"
+    - "HR"
 
 steps:
-  bulk_user_creation:
+  # Faker関数を使ったデータ生成とPOST
+  - desc: ユーザーデータの生成と送信
     loop:
-      count: len(vars.test_users)
-    req:
-      api:///users:
+      count: 3
+    httpbin:
+      /post:
         post:
           body:
-            application/json: "{{ vars.test_users[i] }}"
-    test: current.res.status == 201
+            application/json:
+              id: "{{ i + 1 }}"
+              name: "{{ faker.Name() }}"
+              email: "{{ faker.Email() }}"
+              phone: "{{ faker.Numerify('###-###-####') }}"
+              department: "{{ vars.departments[i % len(vars.departments)] }}"
+              timestamp: "{{ i + 1000 }}"
+    test: |
+      current.res.status == 200 &&
+      current.res.body.json.id == i + 1
 
-  # 生成されたデータの統計分析
-  data_analysis:
-    dump:
-      total_users: len(vars.test_users)
-      active_users: len(filter(vars.test_users, {.active}))
-      avg_age: |
-        sum(map(vars.test_users, {.age})) / len(vars.test_users)
-      departments: |
-        groupBy(vars.test_users, {.department})
-      salary_stats:
-        min: min(map(vars.test_users, {.salary}))
-        max: max(map(vars.test_users, {.salary}))
-        avg: |
-          sum(map(vars.test_users, {.salary})) / len(vars.test_users)
+  # 生成されたデータの検証
+  - desc: データ生成の確認
+    httpbin:
+      /anything:
+        get:
+          query:
+            total_created: "{{ vars.num_users }}"
+          body:
+    test: current.res.status == 200
+    dump: |
+      {
+        "total_users": vars.num_users,
+        "departments_used": vars.departments
+      }

--- a/examples/advanced/debug_output.yml
+++ b/examples/advanced/debug_output.yml
@@ -1,9 +1,9 @@
 desc: デバッグ情報の出力
 runners:
-  api: https://api.example.com
+  httpbin: http://localhost:8080
 
 vars:
-  complex_data:
+  test_data:
     operation: "create"
     resource: "user"
     data:
@@ -11,35 +11,22 @@ vars:
       email: "test@example.com"
 
 steps:
-  debug_step:
-    req:
-      api:///api/complex-operation:
+  - desc: デバッグ情報の収集
+    httpbin:
+      /post:
         post:
+          headers:
+            X-Custom-Header: "test-value"
           body:
-            application/json: "{{ vars.complex_data }}"
+            application/json: "{{ vars.test_data }}"
+    test: current.res.status == 200
     
-    # 詳細なデバッグ情報
-    dump:
-      request_info:
-        url: current.req.url
-        method: current.req.method
-        headers: current.req.headers
-        body_size: len(toJSON(current.req.body))
-      
-      response_info:
-        status: current.res.status
-        headers: current.res.headers
-        body_size: len(toJSON(current.res.body))
-        response_time: current.res.response_time
-      
-      validation_details:
-        expected_fields: ["id", "name", "status"]
-        actual_fields: keys(current.res.body)
-        missing_fields: |
-          filter(["id", "name", "status"], {
-            !(. in keys(current.res.body))
-          })
-        extra_fields: |
-          filter(keys(current.res.body), {
-            !(. in ["id", "name", "status"])
-          })
+    # シンプルなデバッグ情報
+    dump: |
+      {
+        "request_method": "POST",
+        "request_url": "/post",
+        "response_status": current.res.status,
+        "response_data_received": current.res.body.json != null,
+        "posted_data": current.res.body.json
+      }

--- a/examples/advanced/error_handling.yml
+++ b/examples/advanced/error_handling.yml
@@ -1,31 +1,29 @@
 desc: 包括的なエラーハンドリング
 runners:
-  api: https://api.example.com
+  httpbin: http://localhost:8080
 
 vars:
-  resource_id: "res123"
+  max_retries: 3
 
 steps:
-  robust_api_call:
+  # HTTPステータスコードによるリトライ処理
+  - desc: エラーをリトライで処理
     loop:
       count: 3
       until: |
         current.res.status == 200 ||
-        current.res.status == 404  # 404は正常な結果として扱う
-      minInterval: 1
-      maxInterval: 5
-    req:
-      api:///api/resource/{{ vars.resource_id }}:
+        current.res.status == 404  // 404は正常な結果として扱う
+      minInterval: 1s
+      maxInterval: 2s
+    httpbin:
+      /status/200,500,503:  # ランダムにステータスを返す
         get:
+          body:
     test: |
-      current.res.status in [200, 404]
-    
-    dump:
-      # エラー情報の詳細記録
-      error_info: |
-        current.res.status >= 400 ? {
-          "status": current.res.status,
-          "error": current.res.body.error ?? "Unknown error",
-          "timestamp": time.now(),
-          "attempt": i + 1
-        } : null
+      current.res.status in [200, 404, 500, 503]
+    dump: |
+      {
+        "attempt": i + 1,
+        "status": current.res.status,
+        "is_success": current.res.status in [200, 404]
+      }

--- a/examples/advanced/loop_dynamic.yml
+++ b/examples/advanced/loop_dynamic.yml
@@ -1,48 +1,51 @@
 desc: 動的なループ制御
 runners:
-  api: https://api.example.com
+  httpbin: http://localhost:8080
 
 vars:
-  page_size: 10
-  max_pages: 100
   items_to_process:
     - id: 1
       name: "Item 1"
-      needs_processing: true
+      active: true
     - id: 2
       name: "Item 2"
-      needs_processing: false
+      active: false
     - id: 3
       name: "Item 3"
-      needs_processing: true
+      active: true
 
 steps:
-  # ページネーションを使った全データ取得
-  paginated_fetch:
+  # HTTPBinのanythingエンドポイントでページネーションをシミュレート
+  - desc: ページネーションのシミュレーション
     loop:
-      count: vars.max_pages
-      until: len(current.res.body.data) < vars.page_size  # 最後のページに到達
-    req:
-      api:///users:
+      count: 3
+      until: i >= 2  # 3回目で終了
+    httpbin:
+      /anything:
         get:
           query:
             page: "{{ i + 1 }}"
-            limit: "{{ vars.page_size }}"
+            limit: "10"
+          body:
     test: current.res.status == 200
-    dump:
-      page_number: i + 1
-      items_count: len(current.res.body.data)
-      total_fetched: |
-        sum(map(steps.paginated_fetch, {len(.res.body.data)}))
+    dump: |
+      {
+        "page": i + 1,
+        "has_more": i < 2
+      }
 
   # 条件に基づく動的ループ
-  conditional_processing:
+  - desc: アクティブなアイテムのみ処理
     loop:
       count: len(vars.items_to_process)
-    if: vars.items_to_process[i].needs_processing
-    req:
-      api:///process:
+    if: vars.items_to_process[i].active
+    httpbin:
+      /post:
         post:
           body:
-            application/json: "{{ vars.items_to_process[i] }}"
-    test: current.res.status == 200
+            application/json:
+              item_id: "{{ vars.items_to_process[i].id }}"
+              item_name: "{{ vars.items_to_process[i].name }}"
+    test: |
+      current.res.status == 200 &&
+      current.res.body.json.item_id == vars.items_to_process[i].id

--- a/examples/advanced/loop_retry.yml
+++ b/examples/advanced/loop_retry.yml
@@ -1,50 +1,49 @@
 desc: 条件付きループ（リトライ機能）
 runners:
-  api: https://api.example.com
+  httpbin: http://localhost:8080
 
 vars:
-  operation_id: "op123"
+  max_retries: 3
 
 steps:
-  # 成功するまでリトライ
-  retry_until_success:
+  # 成功するまでリトライ（HTTPBinの/status/200を使用）
+  - desc: 成功するまでリトライ
     loop:
-      count: 10  # 最大10回
-      until: current.res.status == 200  # 成功条件
-      minInterval: 1  # 最小間隔（秒）
-      maxInterval: 5  # 最大間隔（秒）
-    req:
-      api:///unstable-endpoint:
+      count: 3
+      until: current.res.status == 200
+      minInterval: 1s
+      maxInterval: 2s
+    httpbin:
+      /status/200:
         get:
+          body:
     test: current.res.status == 200
 
-  # 複雑な条件でのリトライ
-  complex_retry:
+  # ランダムなステータスコードでのリトライ
+  - desc: ランダムステータスでのリトライ
     loop:
       count: 5
+      until: current.res.status == 200
+      minInterval: 500ms
+      maxInterval: 1s
+    httpbin:
+      /status/200,400,500:  # 200, 400, 500のいずれかを返す
+        get:
+          body:
+    test: |
+      current.res.status == 200 || i == 4  # 成功するか最後の試行
+
+  # JSONレスポンスの条件でリトライ
+  - desc: JSONレスポンス条件でのリトライ
+    loop:
+      count: 3
       until: |
         current.res.status == 200 &&
-        current.res.body.status == "ready" &&
-        len(current.res.body.items) > 0
-      minInterval: 2
-      maxInterval: 10
-    req:
-      api:///async-operation/{{ vars.operation_id }}/status:
+        current.res.body.json != null
+    httpbin:
+      /json:
         get:
-    test: |
-      current.res.body.status == "ready"
-
-  # エラー条件でのループ終了
-  stop_on_error:
-    loop:
-      count: 100
-      until: current.res.status >= 400  # エラーが発生したら停止
-    req:
-      api:///batch-process:
-        post:
           body:
-            application/json:
-              batch_id: "{{ i }}"
     test: |
-      current.res.status < 400 ||  # 成功
-      (current.res.status >= 400 && i > 0)  # エラーだが少なくとも1回は成功
+      current.res.status == 200 &&
+      current.res.body.slideshow != null


### PR DESCRIPTION
## Summary
- advanced章のテストファイルをhttpbinサーバーを使用するように修正
- 動作するテストのみをTestAdvancedに追加してCIが通るように調整
- 不安定なテストは除外

## Changes
修正したテストファイル:
- `loop_basic.yml` - 基本的なループテスト
- `conditional_basic.yml` - 条件分岐の基本
- `conditional_complex.yml` - 複雑な条件分岐
- `conditional_error_handling.yml` - エラー時の条件分岐
- `data_generation.yml` - faker関数によるデータ生成（faker.Phone()をfaker.Numerify()に変更）
- `debug_output.yml` - デバッグ出力

除外したテストファイル:
- `error_handling.yml` - ランダムステータスでuntil条件が不安定
- `loop_retry.yml` - ランダムステータスのテストが不安定
- `loop_dynamic.yml` - 配列インデックスアクセスのエラー
- その他のファイル（concurrency、custom_runner、dependency、include等）

## Test plan
- [x] `go test -run TestAdvanced`が通ることを確認
- [ ] GitHub ActionsのCIが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)