### PR TITLE
存在しないloop_dynamic.ymlへの参照を削除

### DIFF
--- a/chapters_test.go
+++ b/chapters_test.go
@@ -46,9 +46,7 @@ func TestAdvanced(t *testing.T) {
 		"examples/advanced/loop_retry.yml",
 		"examples/advanced/conditional_basic.yml",
 		"examples/advanced/include_basic.yml",
-		// 以下のファイルは修正が困難またはエラーが発生
-		// - loop_dynamic.yml (配列インデックスアクセスのエラー)
-		// - common/auth.yml (単体実行用)
+		// common/auth.yml はinclude_basic.ymlからインクルードされるため単体テストは不要
 	})
 }
 


### PR DESCRIPTION
## Summary
- TestAdvancedのコメントから存在しないloop_dynamic.ymlへの参照を削除

## 背景
- loop_dynamic.ymlというファイルは存在しない
- ドキュメントでも使用されていない
- テストのコメントにのみ残っていた

🤖 Generated with [Claude Code](https://claude.ai/code)