### PR TITLE
TestTestHelpersを削除

### DIFF
--- a/chapters_test.go
+++ b/chapters_test.go
@@ -44,10 +44,6 @@ func TestAdvanced(t *testing.T) {
 	testutil.RunChapterTests(t, "examples/advanced")
 }
 
-func TestTestHelpers(t *testing.T) {
-	t.Skip("Skip test-helpers for now")
-	testutil.RunChapterTests(t, "examples/test-helpers")
-}
 
 func TestExprLang(t *testing.T) {
 	testutil.RunChapterTests(t, "examples/expr-lang")


### PR DESCRIPTION
## Summary
- 不要なTestTestHelpers関数を削除

## 理由
- TestTestHelpersは`examples/test-helpers`ディレクトリをテストしようとしていたが、実際のディレクトリ名は`examples/test-helper`
- `examples/test-helper`ディレクトリにはGoプロジェクトが含まれており、これらは個別に`go test`で実行される
- chapters_test.goでYAMLファイルとしてテストする必要はない
- 既にSkipされていた不要なテスト

🤖 Generated with [Claude Code](https://claude.ai/code)