### PR TITLE
章末のナビゲーションリンクを削除

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -40,4 +40,3 @@
 ```
 {{ includex("examples/advanced/include_basic.stdout") }}
 ```
-[第7章：Goテストヘルパー編へ →](test-helper.md)

--- a/docs/scenario.md
+++ b/docs/scenario.md
@@ -184,6 +184,3 @@ HTTPもデータベースも、同じ`test`構文でアサーションを記述�
 ```yaml
 {{ includex("examples/scenario/environment-config.yml") }}
 ```
-
-
-次章では、runnの式評価エンジンについて学びます。前のステップの結果を参照したり、条件分岐やフィルタリングを行う方法を説明します。


### PR DESCRIPTION
## Summary
- 章末に配置されていたナビゲーションリンクを削除

## 削除した内容
- `docs/advanced.md`: 「[第7章：Goテストヘルパー編へ →](test-helper.md)」
- `docs/scenario.md`: 「次章では、runnの式評価エンジンについて学びます。前のステップの結果を参照したり、条件分岐やフィルタリングを行う方法を説明します。」

## 理由
- MkDocsのサイドバーで章間のナビゲーションは提供されている
- 章末リンクは冗長で、ドキュメントの保守性を低下させる

🤖 Generated with [Claude Code](https://claude.ai/code)